### PR TITLE
Add Extension capability for handling custom data types

### DIFF
--- a/src/jc21/CliTable.php
+++ b/src/jc21/CliTable.php
@@ -351,7 +351,7 @@ class CliTable {
                         if (!isset($columnLengths[$key])) {
                             $columnLengths[$key] = 0;
                         }
-                        $columnLengths[$key] = max($columnLengths[$key], strlen($value));
+                        $columnLengths[$key] = max($columnLengths[$key], mb_strlen($value));
                     }
                     $rowCount++;
                 }
@@ -400,7 +400,7 @@ class CliTable {
                 $color = $this->fields[$key]['color'];
             }
 
-            $fieldLength  = strlen($field) + 1;
+            $fieldLength  = mb_strlen($field) + 1;
             $field        = ' '.($this->getUseColors() ? $this->getColorFromName($color) : '').$field;
             $response    .= $field;
 

--- a/src/jc21/CliTable.php
+++ b/src/jc21/CliTable.php
@@ -340,7 +340,7 @@ class CliTable {
                     $cellData[$rowCount] = array();
                     foreach ($this->fields as $field) {
                         $key   = $field['key'];
-                        $value = $row[$key];
+                        $value = $this->getValue($row, $key);
                         if ($field['manipulator'] instanceof CliTableManipulator) {
                             $value = trim($field['manipulator']->manipulate($value, $row, $field['name']));
                         }
@@ -528,6 +528,19 @@ class CliTable {
             return $this->colors[$colorName];
         }
         return $this->colors['reset'];
+    }
+
+
+    /**
+     * getValue
+     *
+     * @access protected
+     * @param  (array | ArrayAccess)  $colorName
+     * @return string
+     */
+    protected function getValue($row, string $key)
+    {
+        return $row[$key];
     }
 
 

--- a/src/jc21/CliTable.php
+++ b/src/jc21/CliTable.php
@@ -335,12 +335,12 @@ class CliTable {
         // Data
         if ($this->injectedData !== null) {
             if (count($this->injectedData)) {
-                foreach ($this->injectedData as $row) {
+                foreach ($this->injectedData as $rowKey => $row) {
                     // Row
                     $cellData[$rowCount] = array();
                     foreach ($this->fields as $field) {
                         $key   = $field['key'];
-                        $value = $this->getValue($row, $key);
+                        $value = $this->getValue($row, $key, $rowKey);
                         if ($field['manipulator'] instanceof CliTableManipulator) {
                             $value = trim($field['manipulator']->manipulate($value, $row, $field['name']));
                         }
@@ -535,10 +535,12 @@ class CliTable {
      * getValue
      *
      * @access protected
-     * @param  (array | ArrayAccess)  $colorName
+     * @param  (array | ArrayAccess)  $row
+     * @param  string  $key
+     * @param  any  $rowKey
      * @return string
      */
-    protected function getValue($row, string $key)
+    protected function getValue($row, string $key, $rowKey)
     {
         return $row[$key];
     }


### PR DESCRIPTION
Hello, 

I made a small modification so I an extend your class and pass any data I want to the renderer. I must handle document objects, and implement `ArrayAccess` is not enough to have correct data :

```PHP

class DocumentTable extends CliTable {

  protected function getValue($doc, string $key)
  {
    return $doc->getMetadata($key, null);
  }

}

```

So maybe you want to merge it :)

I also fixed a bug when displaying data with UTF-8 characters, but maybe that would require to add symfony's mbstring polyfill as a dependency.